### PR TITLE
RestApiv2: Add support for Index + find by PrimaryKey

### DIFF
--- a/astra-sdk/src/test/java/org/datastax/astra/dto/Video.java
+++ b/astra-sdk/src/test/java/org/datastax/astra/dto/Video.java
@@ -1,0 +1,72 @@
+package org.datastax.astra.dto;
+
+/**
+ * 
+ * @author Cedrick LUNVEN (@clunven)
+ */
+public class Video {
+    
+    private String genre;
+    
+    private String title;
+    
+    private int year;
+
+    /**
+     * Getter accessor for attribute 'genre'.
+     *
+     * @return
+     *       current value of 'genre'
+     */
+    public String getGenre() {
+        return genre;
+    }
+
+    /**
+     * Setter accessor for attribute 'genre'.
+     * @param genre
+     * 		new value for 'genre '
+     */
+    public void setGenre(String genre) {
+        this.genre = genre;
+    }
+
+    /**
+     * Getter accessor for attribute 'year'.
+     *
+     * @return
+     *       current value of 'year'
+     */
+    public int getYear() {
+        return year;
+    }
+
+    /**
+     * Setter accessor for attribute 'year'.
+     * @param year
+     * 		new value for 'year '
+     */
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    /**
+     * Getter accessor for attribute 'title'.
+     *
+     * @return
+     *       current value of 'title'
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Setter accessor for attribute 'title'.
+     * @param title
+     * 		new value for 'title '
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+}

--- a/astra-sdk/src/test/java/org/datastax/astra/dto/VideoRowMapper.java
+++ b/astra-sdk/src/test/java/org/datastax/astra/dto/VideoRowMapper.java
@@ -1,0 +1,18 @@
+package org.datastax.astra.dto;
+
+import io.stargate.sdk.rest.domain.Row;
+import io.stargate.sdk.rest.domain.RowMapper;
+
+public class VideoRowMapper implements RowMapper<Video>{
+
+    /** {@inheritDoc} */
+    @Override
+    public Video map(Row row) {
+        Video video = new Video();
+        video.setGenre(row.getString("genre"));
+        video.setTitle(row.getString("title"));
+        video.setYear(row.getInt("year"));
+        return video;
+    }
+
+}

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/ColumnsClient.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/ColumnsClient.java
@@ -164,8 +164,6 @@ public class ColumnsClient {
         try {
            String reqBody = getObjectMapper().writeValueAsString(
                    new ColumnDefinition(newName, find().get().getTypeDefinition()));
-           System.out.println(reqBody);
-           System.out.println(getEndPointSchemaCurrentColumn());
            response = getHttpClient()
                    .send(startRequest(
                           getEndPointSchemaCurrentColumn(), restClient.getToken())

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/IndexClient.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/IndexClient.java
@@ -1,0 +1,130 @@
+package io.stargate.sdk.rest;
+
+import static io.stargate.sdk.core.ApiSupport.getHttpClient;
+import static io.stargate.sdk.core.ApiSupport.getObjectMapper;
+import static io.stargate.sdk.core.ApiSupport.handleError;
+import static io.stargate.sdk.core.ApiSupport.startRequest;
+
+import java.net.HttpURLConnection;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Optional;
+
+import io.stargate.sdk.rest.domain.CreateIndex;
+import io.stargate.sdk.rest.domain.IndexDefinition;
+import io.stargate.sdk.rest.exception.IndexNotFoundException;
+import io.stargate.sdk.utils.Assert;
+
+/**
+ * Working with indices in the classes.
+ *
+ * @author Cedrick LUNVEN (@clunven)
+ */
+public class IndexClient {
+
+    /** Astra Client. */
+    private final ApiRestClient restClient;
+    
+    /** Namespace. */
+    private final KeyspaceClient keyspaceClient;
+    
+    /** Namespace. */
+    private final TableClient tableClient;
+    
+    /** Unique document identifer. */
+    private final String indexName;
+    
+    /**
+     * Constructor focusing on a single Column
+     *
+     * @param restClient
+     *      working with rest
+     * @param keyspaceClient
+     *      keyspace resource client
+     * @param tableClient
+     *       table resource client
+     * @param indexName
+     *      current index identifier
+     */
+    public IndexClient(ApiRestClient restClient, KeyspaceClient keyspaceClient, TableClient tableClient, String indexName) {
+        this.restClient     = restClient;
+        this.keyspaceClient = keyspaceClient;
+        this.tableClient    = tableClient;
+        this.indexName       = indexName;
+    }
+    
+    /**
+     * Syntax sugar
+     */
+    public String getEndPointSchemaCurrentIndex() {
+        return keyspaceClient.getEndPointSchemaKeyspace() 
+                + "/tables/"  + tableClient.getTableName()
+                + "/indexes/" + indexName;
+    }
+    
+    /**
+     * Get metadata of the collection. There is no dedicated resources we
+     * use the list and filter with what we need.
+     *
+     * @return
+     *      metadata of the collection if its exist or empty
+     */
+    public Optional<IndexDefinition> find() {
+        return tableClient.indexes()
+                .filter(i -> indexName.equalsIgnoreCase(i.getIndex_name()))
+                .findFirst();
+    }
+    
+    /**
+     * Check if the column exist on the 
+     * @return
+     */
+    public boolean exist() {
+        return tableClient.indexesNames().anyMatch(indexName::equals);
+    }
+    
+    /**
+     * Add an index.
+     *
+     * @param ci
+     *      new index to create
+     */
+    public void create(CreateIndex ci) {
+        Assert.notNull(ci, "CreateIndex");
+        ci.setName(indexName);
+        HttpResponse<String> response;
+        try {
+           String reqBody = getObjectMapper().writeValueAsString(ci);
+           response = getHttpClient().send(startRequest(
+                           keyspaceClient.getEndPointSchemaKeyspace() 
+                           + "/tables/"  + tableClient.getTableName()
+                           + "/indexes", restClient.getToken())
+                   .POST(BodyPublishers.ofString(reqBody)).build(),
+                   BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot create a new index:", e);
+        }
+        handleError(response);
+    }
+    
+    /**
+     * Delete an index.
+     */
+    public void delete() {
+        HttpResponse<String> response;
+        try {
+            // Invoke
+            response = getHttpClient().send(
+                    startRequest(getEndPointSchemaCurrentIndex(), restClient.getToken())
+                    .DELETE().build(), BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot retrieve table list", e);
+        }
+        if (HttpURLConnection.HTTP_NOT_FOUND == response.statusCode()) {
+            throw new IndexNotFoundException(indexName);
+        }
+        handleError(response);
+    }
+    
+}

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/CreateIndex.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/CreateIndex.java
@@ -1,0 +1,173 @@
+package io.stargate.sdk.rest.domain;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Creation request for an INDEX.
+ *
+ * @author Cedrick LUNVEN (@clunven)
+ */
+public class CreateIndex implements Serializable {
+
+    /** Serial Number. */
+    private static final long serialVersionUID = -5374080080154230782L;
+    
+    /** Limited values for the kind. */
+    private static enum IndexKind { KEYS, VALUES, ENTRIES, FULL }
+    
+    /** Constant for a SASI index. */
+    public static final String TYPE_SASI = "org.apache.cassandra.index.sasi.SASIIndex";
+    
+    /** Constant for a SAI index. */
+    public static final String TYPE_SAI  = "org.apache.cassandra.index.sai.StorageAttachedIndex";
+    
+    /** Identifer of the index. */
+    private String name;
+    
+    /** Name of the column. */
+    private final String column;
+  
+    /** CREATE IF NOT EXIST. */
+    private final boolean ifNotExists;
+    
+    /** Custom type. */
+    private final String type;
+    
+    /** Default value for index. */
+    private final IndexKind kind;
+    
+    /** Index options. */
+    private final Map<String, String> options;
+
+    /**
+     * Constructor.
+     * @param builder
+     */
+    private CreateIndex(CreateIndexBuilder builder) {
+        this.name         = builder.name;
+        this.column       = builder.column;
+        this.ifNotExists  = builder.ifNotExists;
+        this.type         = builder.type;
+        this.kind         = builder.kind;
+        this.options      = builder.options;
+    }
+    
+    public static CreateIndexBuilder builder() {
+        return new CreateIndexBuilder();
+    }
+    
+    public static class CreateIndexBuilder {
+        boolean ifNotExists = false;
+        String name;
+        String column;
+        String type = null;
+        IndexKind kind = null;
+        Map<String, String> options = null;
+        
+        public CreateIndex build() {
+            return new CreateIndex(this);
+        }
+        public CreateIndexBuilder ifNotExist(boolean ine) {
+            this.ifNotExists = ine;
+            return this;
+        }
+        public CreateIndexBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+        public CreateIndexBuilder type(String t) {
+            this.type = t;
+            return this;
+        }
+        public CreateIndexBuilder sasi() {
+            return type(TYPE_SASI);
+        }
+        public CreateIndexBuilder column(String name) {
+            this.column = name;
+            return this;
+        }
+        public CreateIndexBuilder kind(IndexKind k) {
+            this.kind = k;
+            return this;
+        }
+        public CreateIndexBuilder addOption(String key, String value) {
+            if (options == null) {
+                options = new HashMap<>();
+            }
+            this.options.put(key, value);
+            return this;
+        }
+    }
+
+    /**
+     * Getter accessor for attribute 'name'.
+     *
+     * @return
+     *       current value of 'name'
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Getter accessor for attribute 'column'.
+     *
+     * @return
+     *       current value of 'column'
+     */
+    public String getColumn() {
+        return column;
+    }
+
+    /**
+     * Getter accessor for attribute 'ifNotExists'.
+     *
+     * @return
+     *       current value of 'ifNotExists'
+     */
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
+    /**
+     * Getter accessor for attribute 'type'.
+     *
+     * @return
+     *       current value of 'type'
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Getter accessor for attribute 'kind'.
+     *
+     * @return
+     *       current value of 'kind'
+     */
+    public IndexKind getKind() {
+        return kind;
+    }
+
+    /**
+     * Getter accessor for attribute 'options'.
+     *
+     * @return
+     *       current value of 'options'
+     */
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    /**
+     * Setter accessor for attribute 'name'.
+     * @param name
+     * 		new value for 'name '
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/IndexDefinition.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/IndexDefinition.java
@@ -1,0 +1,132 @@
+package io.stargate.sdk.rest.domain;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Sample output
+ * 
+ * {
+ *  "keyspace_name": "sdk_test_ks",
+ *  "options": [
+ *   { "key": "class_name", "value": "org.apache.cassandra.index.sai.StorageAttachedIndex" },
+ *   { "key": "target", "value": "keys(bar2)" }
+ *  ],
+ *  "table_name": "foo",
+ *  "index_name": "idx_2",
+ *  "kind": "CUSTOM"
+ * }
+ *
+ * @author Cedrick LUNVEN (@clunven)
+ */
+public class IndexDefinition implements Serializable {
+    
+    /** Serial. */
+    private static final long serialVersionUID = 460202584337456067L;
+
+    private String index_name;
+    
+    private String table_name;
+    
+    private String keyspace_name;
+    
+    private List<KVPair> options;
+    
+    private String kind;
+
+    /**
+     * Getter accessor for attribute 'index_name'.
+     *
+     * @return
+     *       current value of 'index_name'
+     */
+    public String getIndex_name() {
+        return index_name;
+    }
+
+    /**
+     * Setter accessor for attribute 'index_name'.
+     * @param index_name
+     * 		new value for 'index_name '
+     */
+    public void setIndex_name(String index_name) {
+        this.index_name = index_name;
+    }
+
+    /**
+     * Getter accessor for attribute 'table_name'.
+     *
+     * @return
+     *       current value of 'table_name'
+     */
+    public String getTable_name() {
+        return table_name;
+    }
+
+    /**
+     * Setter accessor for attribute 'table_name'.
+     * @param table_name
+     * 		new value for 'table_name '
+     */
+    public void setTable_name(String table_name) {
+        this.table_name = table_name;
+    }
+
+    /**
+     * Getter accessor for attribute 'keyspace_name'.
+     *
+     * @return
+     *       current value of 'keyspace_name'
+     */
+    public String getKeyspace_name() {
+        return keyspace_name;
+    }
+
+    /**
+     * Setter accessor for attribute 'keyspace_name'.
+     * @param keyspace_name
+     * 		new value for 'keyspace_name '
+     */
+    public void setKeyspace_name(String keyspace_name) {
+        this.keyspace_name = keyspace_name;
+    }
+
+    /**
+     * Getter accessor for attribute 'options'.
+     *
+     * @return
+     *       current value of 'options'
+     */
+    public List<KVPair> getOptions() {
+        return options;
+    }
+
+    /**
+     * Setter accessor for attribute 'options'.
+     * @param options
+     * 		new value for 'options '
+     */
+    public void setOptions(List<KVPair> options) {
+        this.options = options;
+    }
+
+    /**
+     * Getter accessor for attribute 'kind'.
+     *
+     * @return
+     *       current value of 'kind'
+     */
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * Setter accessor for attribute 'kind'.
+     * @param kind
+     * 		new value for 'kind '
+     */
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+}

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/KVPair.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/KVPair.java
@@ -1,0 +1,56 @@
+package io.stargate.sdk.rest.domain;
+
+/**
+ * Wrapper for entries in map.
+ *
+ * @author Cedrick LUNVEN (@clunven)
+ */
+public class KVPair {
+    
+    /** key. */
+    private String key;
+    
+    /** value. */
+    private String value;
+
+    /**
+     * Getter accessor for attribute 'key'.
+     *
+     * @return
+     *       current value of 'key'
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Setter accessor for attribute 'key'.
+     * @param key
+     * 		new value for 'key '
+     */
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Getter accessor for attribute 'value'.
+     *
+     * @return
+     *       current value of 'value'
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Setter accessor for attribute 'value'.
+     * @param value
+     * 		new value for 'value '
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+    
+    
+
+}

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/Row.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/domain/Row.java
@@ -2,11 +2,52 @@ package io.stargate.sdk.rest.domain;
 
 import java.util.HashMap;
 
+/**
+ * Wrapper to parse Rows as an HashMap.
+ * 
+ * @author Cedrick LUNVEN (@clunven)
+ */
 public class Row extends HashMap<String, Object> {
 
     /** Serial. */
     private static final long serialVersionUID = 3279531139420446635L;
     
+    /**
+     * Retrieve value and check existence.
+     *
+     * @param colName
+     *      column name
+     * @return
+     *      value if exist or error
+     */
+    public Object get(String colName) {
+        if (!containsKey(colName)) {
+            throw new IllegalArgumentException("Cannot find column "
+                    + "with name '" + colName + "', available columns are " + keySet());
+        }
+        return super.get(colName);
+    }
+    
+    /**
+     * Retrieve a column value as a String.
+     */
+    public String getString(String colName) {
+        return String.valueOf(get(colName));
+    }
+    
+    /**
+     * Retrieve a column value as a Double.
+     */
+    public Double getDouble(String colName) {
+        return Double.valueOf(getString(colName));
+    }
+    
+    /**
+     * Retrieve a column value as an Integer.
+     */
+    public Integer getInt(String colName) {
+        return getDouble(colName).intValue();
+    }
     
 
 }

--- a/stargate-sdk/src/main/java/io/stargate/sdk/rest/exception/IndexNotFoundException.java
+++ b/stargate-sdk/src/main/java/io/stargate/sdk/rest/exception/IndexNotFoundException.java
@@ -1,0 +1,21 @@
+package io.stargate.sdk.rest.exception;
+
+/**
+ * Specialized Error.
+ *
+ * @author Cedrick LUNVEN (@clunven)
+ */
+public class IndexNotFoundException extends RuntimeException {
+    
+    /** Serial. */
+    private static final long serialVersionUID = -4491748257797687008L;
+
+    public IndexNotFoundException(String idxName) {
+        super("Cannot find Index " + idxName);
+    }
+    
+    public IndexNotFoundException(String idxName, Throwable parent) {
+        super("Cannot find Index " + idxName, parent);
+    }
+
+}


### PR DESCRIPTION
Sample Code:

```java
TableClient tableVideo = clientApiRest.keyspace("ks1").table("videos");

// Create an index
tableVideo.index("idx_test").create(CreateIndex.builder().column("title").build());
// Also valid syntax;
tableVideo.createIndex("idx_test", CreateIndex.builder().column("title").build());

// Delete an index
tableVideo.index("idx_test").delete();

// Search by PK
RowResultPage rawResultPage = tableVideo.findByPrimaryKey(
  QueryRowsByPrimaryKey.builder()
                .primaryKey("Action","2021")
                .addSortedField("year", Ordering.ASC)
                .build());

// Search by PK with Object Mapping
ResultPage<Video> resultPage = tableVideo.findByPrimaryKey(
  QueryRowsByPrimaryKey.builder()
                .primaryKey("Action","2021")
                .addSortedField("year", Ordering.ASC)
                .build(), new VideoRowMapper());
```