### PR TITLE
root level to info

### DIFF
--- a/astra-sdk/src/main/resources/logback.xml
+++ b/astra-sdk/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
         <appender-ref ref="STDOUT" />
     </logger>
     -->
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
SDK overrides Spring Boot's root logging level (set to INFO by default). 
New SDK users may be confused due to the empty logs