### PR TITLE
Change Jackson dependency to use jackson-bom for fully consistent set of components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,19 +82,11 @@
 			
 			<!-- Working with JSON -->
 			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
 				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>${jackson.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
 			</dependency>
 			<dependency>
 	    		<groupId>org.everit.json</groupId>


### PR DESCRIPTION
So, instead of only listing components we need directly, use `jackson-bom` which has a full set: this is important in ensuring that transitive dependencies to Jackson artifacts have same version as one we use.
