### PR TITLE
Clean up comments and parameter names in Connecting.java

### DIFF
--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Connecting.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Connecting.java
@@ -4,15 +4,15 @@ import com.dtsx.astra.sdk.AstraDB;
 import java.util.UUID;
 
 public class Connecting {
-    public static void main(String[] args) {
-        // Default initialization
-        AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+  public static void main(String[] args) {
+    // Default initialization
+    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
 
-        // Initialize with a non-default keyspace
-        AstraDB db1 = new AstraDB("<token>", "<api_endpoint>", "<keyspace>");
+    // Initialize with a non-default keyspace
+    AstraDB db1 = new AstraDB("<token>", "<api_endpoint>", "<keyspace>");
 
-        // Initialize with an identifier instead of an endpoint
-        UUID databaseUuid = UUID.fromString("<database_id>");
-        AstraDB db2 = new AstraDB("<token>", databaseUuid);
-    }
+    // Initialize with an identifier instead of an endpoint
+    UUID databaseUuid = UUID.fromString("<database_id>");
+    AstraDB db2 = new AstraDB("<token>", databaseUuid);
+  }
 }

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Connecting.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Connecting.java
@@ -1,20 +1,17 @@
 package com.dtsx.astra.sdk.documentation;
 
 import com.dtsx.astra.sdk.AstraDB;
-
 import java.util.UUID;
 
 public class Connecting {
     public static void main(String[] args) {
-        // Default Initialization
+        // Default initialization
         AstraDB db = new AstraDB("<token>", "<api_endpoint>");
 
-        // --- Other Initializations ---
+        // Initialize with a non-default keyspace
+        AstraDB db1 = new AstraDB("<token>", "<api_endpoint>", "<keyspace>");
 
-        // (1) using non-default keyspace
-        AstraDB db1 = new AstraDB("<token>", "<api_endpoint>", "<keyspac_name>e");
-
-        // (2) using identifier instead of endpoint (regions LB
+        // Initialize with an identifier instead of an endpoint
         UUID databaseUuid = UUID.fromString("<database_id>");
         AstraDB db2 = new AstraDB("<token>", databaseUuid);
     }


### PR DESCRIPTION
* Reduce the # of lines
* Tidy up comments and parameter placeholders
* Use standard two-space indent (https://google.github.io/styleguide/javaguide.html#s4.2-block-indentation)
* Remove space between import statements (there should only be a space between static and non-static imports: https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing)