### PR TITLE
Tidy up comments and code in CreateDatabase.java

### DIFF
--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/CreateDatabase.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/CreateDatabase.java
@@ -2,18 +2,17 @@ package com.dtsx.astra.sdk.documentation;
 
 import com.dtsx.astra.sdk.AstraDBAdmin;
 import com.dtsx.astra.sdk.db.domain.CloudProviderType;
-
 import java.util.UUID;
 
 public class CreateDatabase {
-    public static void main(String[] args) {
-AstraDBAdmin client = new AstraDBAdmin("<replace_with_token>");
+  public static void main(String[] args) {
+    AstraDBAdmin client = new AstraDBAdmin("<token>");
 
-String databaseName = "<replace_with_db_name>";
-// GCP, AZURE or AWS
-CloudProviderType cloudProvider = CloudProviderType.GCP;
-// To get the list of available regions see below
-String cloudRegion = "us-east1";
-UUID newDbId = client.createDatabase(databaseName, cloudProvider, cloudRegion);
-}
+    // Choose a cloud provider (GCP, AZURE, AWS) and a region
+    CloudProviderType cloudProvider = CloudProviderType.GCP;
+    String cloudRegion = "us-east1";
+
+    // Create a database
+    UUID newDbId = client.createDatabase("<database_name>", cloudProvider, cloudRegion);
+  }
 }


### PR DESCRIPTION
* Use the standard two-space indent for Java (https://google.github.io/styleguide/javaguide.html#s4.2-block-indentation)
* Restructure the code a bit to put cloud provider and region definition under the same comment
* Simplify some of the placeholders
* Remove the explicit `databaseName` variable to save space
* Remove empty space between sets of import statements to save space (spaces should only be used to divide static and non-static imports: https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing)