### PR TITLE
Tidy the comments in ClearCollection.java

### DIFF
--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ClearCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ClearCollection.java
@@ -4,16 +4,11 @@ import com.dtsx.astra.sdk.AstraDB;
 import com.dtsx.astra.sdk.AstraDBCollection;
 
 public class ClearCollection {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
+    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
-// Accessing existing DB
-AstraDB db = new AstraDB("<token>", "<api_endpoint>");
-
-// Access existing collection
-AstraDBCollection collection = db.createCollection("collection_vector1", 14);
-
-// Clear collection
-collection.deleteAll();
-
-    }
+    // Delete all rows from an existing collection
+    collection.deleteAll();
+  }
 }


### PR DESCRIPTION
* Remove comments that aren't core to the focus of this code example
* Use the default two-space indentation for Java code files