### PR TITLE
Tidy the comments in ConnectingAdmin.java

### DIFF
--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ConnectingAdmin.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ConnectingAdmin.java
@@ -2,18 +2,15 @@ package com.dtsx.astra.sdk.documentation;
 
 import com.dtsx.astra.sdk.AstraDB;
 import com.dtsx.astra.sdk.AstraDBAdmin;
-
 import java.util.UUID;
 
 public class ConnectingAdmin {
-    public static void main(String[] args) {
-        // Default Initialization
-        AstraDBAdmin client = new AstraDBAdmin("<token>");
+  public static void main(String[] args) {
+    // Default Initialization
+    AstraDBAdmin client = new AstraDBAdmin("<token>");
 
-        /*
-         * You can omit the token if you defined the environment variable
-         * `ASTRA_DB_APPLICATION_TOKEN` or you if are using the Astra CLI.
-         */
-        AstraDBAdmin defaultClient=new AstraDBAdmin();
-    }
+    // You can omit the token if you defined the `ASTRA_DB_APPLICATION_TOKEN`
+    // environment variable or if you are using the Astra CLI.
+    AstraDBAdmin defaultClient=new AstraDBAdmin();
+  }
 }


### PR DESCRIPTION
* Use the standard two-space indentation
* Replace multi-line comment with two single line comments to save a bit of space (this is okay per https://google.github.io/styleguide/javaguide.html#s4.8.6-comments)
* Reword comments slightly
* Remove space between import statements to save a line (spaces between import statements should only be used to divide static and non-static imports: https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing)