### PR TITLE
Update InsertOne.java

### DIFF
--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/InsertOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/InsertOne.java
@@ -53,13 +53,6 @@ public class InsertOne {
                   "\"product_price\": 9.99" +
                   "}"));
 
-    // You cannot insert a document with an existing ID
-    try {
-        collection.insertOne(new JsonDocument("doc4"));
-    } catch(JsonApiException e) {
-        System.out.println("Expected ERROR: " + e.getMessage());
-    }
-
     // If you do not provide an ID, they are generated automatically
     String generatedId = collection.insertOne(
         new JsonDocument().put("demo", 1));


### PR DESCRIPTION
Removing the duplicate ID error case in favor of adding an explicit note that this is disallowed to the Java client reference docs.