### PR TITLE
Make placeholders comply with the Google Developer Docs Style Guide

### DIFF
--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ClearCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ClearCollection.java
@@ -5,7 +5,7 @@ import com.dtsx.astra.sdk.AstraDBCollection;
 
 public class ClearCollection {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Delete all rows from an existing collection

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Connecting.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Connecting.java
@@ -6,13 +6,13 @@ import java.util.UUID;
 public class Connecting {
   public static void main(String[] args) {
     // Default initialization
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Initialize with a non-default keyspace
-    AstraDB db1 = new AstraDB("<token>", "<api_endpoint>", "<keyspace>");
+    AstraDB db1 = new AstraDB("TOKEN", "API_ENDPOINT", "<keyspace>");
 
     // Initialize with an identifier instead of an endpoint
     UUID databaseUuid = UUID.fromString("<database_id>");
-    AstraDB db2 = new AstraDB("<token>", databaseUuid);
+    AstraDB db2 = new AstraDB("TOKEN", databaseUuid);
   }
 }

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ConnectingAdmin.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ConnectingAdmin.java
@@ -5,7 +5,7 @@ import com.dtsx.astra.sdk.AstraDBAdmin;
 public class ConnectingAdmin {
   public static void main(String[] args) {
     // Default Initialization
-    AstraDBAdmin client = new AstraDBAdmin("<token>");
+    AstraDBAdmin client = new AstraDBAdmin("TOKEN");
 
     // You can omit the token if you defined the `ASTRA_DB_APPLICATION_TOKEN`
     // environment variable or if you are using the Astra CLI.

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/CreateCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/CreateCollection.java
@@ -8,7 +8,7 @@ import io.stargate.sdk.data.exception.DataApiException;
 
 public class CreateCollection {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Create a non-vector collection
     AstraDBCollection collection1 = db.createCollection("collection_simple");

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/CreateDatabase.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/CreateDatabase.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 public class CreateDatabase {
   public static void main(String[] args) {
-    AstraDBAdmin client = new AstraDBAdmin("<token>");
+    AstraDBAdmin client = new AstraDBAdmin("TOKEN");
 
     // Choose a cloud provider (GCP, AZURE, AWS) and a region
     CloudProviderType cloudProvider = CloudProviderType.GCP;

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteCollection.java
@@ -4,7 +4,7 @@ import com.dtsx.astra.sdk.AstraDB;
 
 public class DeleteCollection {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Delete an existing collection
     db.deleteCollection("collection_vector2");

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteDatabase.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteDatabase.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 public class DeleteDatabase {
   public static void main(String[] args) {
-    AstraDBAdmin client = new AstraDBAdmin("<token>");
+    AstraDBAdmin client = new AstraDBAdmin("TOKEN");
 
     // Delete an existing database
     client.deleteDatabaseByName("<database_name>");

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteMany.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteMany.java
@@ -6,7 +6,7 @@ import io.stargate.sdk.data.domain.query.DeleteQuery;
 
 public class DeleteMany {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Delete items from an existing collection with a query

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/DeleteOne.java
@@ -6,7 +6,7 @@ import io.stargate.sdk.data.domain.query.DeleteQuery;
 
 public class DeleteOne {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Delete items from an existing collection with a query

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Find.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/Find.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class Find {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Retrieve the first document with a product_price

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindAllCollections.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindAllCollections.java
@@ -5,7 +5,7 @@ import io.stargate.sdk.data.domain.CollectionDefinition;
 
 public class FindAllCollections {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Iterate over all collections and print each vector definition
     db.findAllCollections().forEach(col -> {

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindAllDatabases.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindAllDatabases.java
@@ -6,7 +6,7 @@ import java.util.stream.Stream;
 
 public class FindAllDatabases {
   public static void main(String[] args) {
-    AstraDBAdmin client = new AstraDBAdmin("<token>");
+    AstraDBAdmin client = new AstraDBAdmin("TOKEN");
     boolean exists = client.isDatabaseExists("<database_name>");
 
     // List all available databases

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindById.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindById.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public class FindById {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.collection("collection_vector1");
 
     // Fetch a document by ID and return it as JSON

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindByVector.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindByVector.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public class FindByVector {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.collection("collection_vector1");
 
     // Fetch a row by vector and return JSON

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindCollection.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public class FindCollection {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Find a collection
     Optional<CollectionDefinition> collection = db.findCollection("collection_vector1");

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindDatabase.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindDatabase.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 
 public class FindDatabase {
   public static void main(String[] args) {
-    AstraDBAdmin client = new AstraDBAdmin("<token>");
+    AstraDBAdmin client = new AstraDBAdmin("TOKEN");
 
     // Check if a database exists
     boolean exists = client.isDatabaseExists("<database_name>");

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindOne.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class FindOne {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Retrieve the first document where product_price exists

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindPage.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindPage.java
@@ -10,7 +10,7 @@ import io.stargate.sdk.data.domain.query.SelectQuery;
 
 public class FindPage {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Retrieve page 1 of a search (up to 20 results)

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindVector.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/FindVector.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 
 public class FindVector {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     float[] embeddings = new float[]{1f, 0f, 1f, 1f, 1f, 1f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f};

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/InsertMany.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/InsertMany.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class InsertMany {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1",14);
 
     // Insert documents into the collection (IDs are generated automatically)

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/InsertOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/InsertOne.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class InsertOne {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Assumes a collection with a vector field of dimension 14
     AstraDBCollection collection = db.collection("collection_vector1");

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingClearCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingClearCollection.java
@@ -11,7 +11,7 @@ public class ObjectMappingClearCollection {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> collection1 =
         db.createCollection("collection_simple", Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingCreateCollection.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingCreateCollection.java
@@ -14,7 +14,7 @@ public class ObjectMappingCreateCollection {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Create a non-vector collection
     AstraDBRepository<Product> collection1 =

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingDeleteMany.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingDeleteMany.java
@@ -12,7 +12,7 @@ public class ObjectMappingDeleteMany {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Create a vector collection
     AstraDBRepository<Product> collection1 =

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingDeleteOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingDeleteOne.java
@@ -12,7 +12,7 @@ public class ObjectMappingDeleteOne {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> collection1 =
         db.createCollection("collection_simple", Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingFind.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingFind.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class ObjectMappingFind {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.createCollection("collection_vector1", 14);
 
     // Retrieve the first document with a product_price

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingFindOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingFindOne.java
@@ -13,7 +13,7 @@ public class ObjectMappingFindOne {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingFindVector.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingFindVector.java
@@ -15,7 +15,7 @@ public class ObjectMappingFindVector {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingInsertMany.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingInsertMany.java
@@ -18,7 +18,7 @@ public class ObjectMappingInsertMany {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingInsertOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingInsertOne.java
@@ -16,7 +16,7 @@ public class ObjectMappingInsertOne {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingPaging.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingPaging.java
@@ -13,7 +13,7 @@ public class ObjectMappingPaging {
     @JsonProperty("product_price") private Double price;
   }
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingUpdateMany.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingUpdateMany.java
@@ -19,7 +19,7 @@ public class ObjectMappingUpdateMany {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingUpdateOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/ObjectMappingUpdateOne.java
@@ -16,7 +16,7 @@ public class ObjectMappingUpdateOne {
   }
 
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBRepository<Product> productRepository =
         db.createCollection("collection_vector1", 14, Product.class);
 

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/QuickStart.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/QuickStart.java
@@ -13,7 +13,7 @@ public class QuickStart {
   public static void main(String[] args) {
 
     // Initialize the client
-    AstraDB myDb = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB myDb = new AstraDB("TOKEN", "API_ENDPOINT");
 
     // Create a collection
     AstraDBCollection demoCollection = myDb.createCollection("demo",14);

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/UpdateMany.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/UpdateMany.java
@@ -6,7 +6,7 @@ import io.stargate.sdk.data.domain.query.UpdateQuery;
 
 public class UpdateMany {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.collection("collection_vector1");
 
     // Update multiple documents based on a query

--- a/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/UpdateOne.java
+++ b/astra-db-client/src/test/java/com/dtsx/astra/sdk/documentation/UpdateOne.java
@@ -7,7 +7,7 @@ import io.stargate.sdk.data.domain.query.UpdateQuery;
 
 public class UpdateOne {
   public static void main(String[] args) {
-    AstraDB db = new AstraDB("<token>", "<api_endpoint>");
+    AstraDB db = new AstraDB("TOKEN", "API_ENDPOINT");
     AstraDBCollection collection = db.collection("collection_vector1");
 
     // You must delete any existing rows with the same IDs as the


### PR DESCRIPTION
Placeholders should be formatted in all caps with underscores to separate words, per the [Google Developer Docs Style Guide](https://developers.google.com/style/placeholders).

This PR is related to: https://github.com/riptano/astra-vector-docs/pull/238