### PR TITLE
Support for database clone operations

### DIFF
--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbCloneClient.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbCloneClient.java
@@ -25,6 +25,12 @@ public class DbCloneClient extends AbstractApiClient {
     /** Clone path component, part II. */
     public static final String PATH_CLONE_2 = "/cloneFrom/";
 
+    /** Get-clone-status path component, part I. */
+    public static final String PATH_GETSTATUS_1 = "/databases/";
+
+    /** Get-clone-status path component, part II. */
+    public static final String PATH_GETSTATUS_2 = "/cloneStatus/";
+
     /**
      * unique db identifier.
      */
@@ -108,15 +114,45 @@ public class DbCloneClient extends AbstractApiClient {
     }
 
     /**
+     * Get the status of a clone operation.
+     *
+     * @param operationId
+     *         ID of the clone operation
+     * @return clone status
+     */
+    public DatabaseCloneStatus getCloneStatus(String operationId) {
+        Assert.hasLength(operationId, "operationId");
+
+        // Build URL
+        String url = getEndpointGetCloneStatus(operationId);
+
+        // Fire GET request
+        ApiResponseHttp res = GET(url, getOperationName("getCloneStatus"));
+
+        // Parse and return response
+        return JsonUtils.unmarshallBean(res.getBody(), DatabaseCloneStatus.class);
+    }
+
+    /**
      * Endpoint to initiate DB clone
      *
      * @param sourceDbId
      *         ID of the source database
-     * @return database endpoint
+     * @return request endpoint
      */
     private String getEndpointCloneFrom(String sourceDbId) {
         return ApiLocator.getApiDevopsEndpoint(environment) + PATH_CLONE_1 + db.getId() + PATH_CLONE_2 + sourceDbId;
     }
 
+    /**
+     * Endpoint to retrieve a DB-clone status (by operation ID)
+     *
+     * @param operationId
+     *         ID of the clone operation (as obtained e.g. with a cloneFrom previous invocation)
+     * @return request endpoint
+     */
+    private String getEndpointGetCloneStatus(String operationId) {
+        return ApiLocator.getApiDevopsEndpoint(environment) + PATH_GETSTATUS_1 + db.getId() + PATH_GETSTATUS_2 + operationId;
+    }
 
 }

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbCloneClient.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbCloneClient.java
@@ -1,0 +1,122 @@
+package com.dtsx.astra.sdk.db;
+
+import com.dtsx.astra.sdk.AbstractApiClient;
+import com.dtsx.astra.sdk.db.domain.Database;
+import com.dtsx.astra.sdk.db.domain.DatabaseCloneStatus;
+import com.dtsx.astra.sdk.utils.ApiLocator;
+import com.dtsx.astra.sdk.utils.ApiResponseHttp;
+import com.dtsx.astra.sdk.utils.Assert;
+import com.dtsx.astra.sdk.utils.AstraEnvironment;
+import com.dtsx.astra.sdk.utils.JsonUtils;
+
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+/**
+ * Delegate operation on DB cloning
+ */
+public class DbCloneClient extends AbstractApiClient {
+
+    /** Clone path component, part I. */
+    public static final String PATH_CLONE_1 = "/databases/";
+
+    /** Clone path component, part II. */
+    public static final String PATH_CLONE_2 = "/cloneFrom/";
+
+    /**
+     * unique db identifier.
+     */
+    private final Database db;
+
+    /**
+     * As immutable object use builder to initiate the object.
+     *
+     * @param token
+     *      authenticated token
+     * @param databaseId
+     *      database identifier
+     */
+    public DbCloneClient(String token, String databaseId) {
+        this(token, AstraEnvironment.PROD, databaseId);
+    }
+
+    /**
+     * As immutable object use builder to initiate the object.
+     *
+     * @param env
+     *      define target environment to be used
+     * @param token
+     *      authenticated token
+     * @param databaseId
+     *      database identifier
+     */
+    public DbCloneClient(String token, AstraEnvironment env, String databaseId) {
+        super(token, env);
+        Assert.hasLength(databaseId, "databaseId");
+        this.db = new DbOpsClient(token, env, databaseId).get();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getServiceName() {
+        return "db.clone";
+    }
+
+    /**
+     * Clone database from a source database using a snapshot.
+     *
+     * @param sourceDbId
+     *         ID of the source database
+     * @param databaseSnapshotId
+     *         ID of the snapshot to clone from
+     * @return clone status
+     */
+    public DatabaseCloneStatus cloneFrom(String sourceDbId, String databaseSnapshotId) {
+        return cloneFrom(sourceDbId, databaseSnapshotId, null);
+    }
+
+    /**
+     * Clone database from a source database using a snapshot.
+     *
+     * @param sourceDbId
+     *         ID of the source database
+     * @param databaseSnapshotId
+     *         ID of the snapshot to clone from
+     * @param sourceRegion
+     *         Source region (optional)
+     * @return clone status
+     */
+    public DatabaseCloneStatus cloneFrom(String sourceDbId, String databaseSnapshotId, String sourceRegion) {
+        Assert.hasLength(sourceDbId, "sourceDbId");
+        Assert.hasLength(databaseSnapshotId, "databaseSnapshotId");
+        
+        // Build URL with query parameters
+        String url = getEndpointCloneFrom(sourceDbId) +
+                     "?snapshotID=" + URLEncoder.encode(databaseSnapshotId, StandardCharsets.UTF_8);
+        
+        if (sourceRegion != null && !sourceRegion.isEmpty()) {
+            url += "&sourceRegion=" + URLEncoder.encode(sourceRegion, StandardCharsets.UTF_8);
+        }
+        
+        // Fire POST request
+        ApiResponseHttp res = POST(url, getOperationName("cloneFrom"));
+        
+        // Parse and return response
+        return JsonUtils.unmarshallBean(res.getBody(), DatabaseCloneStatus.class);
+    }
+
+    /**
+     * Endpoint to initiate DB clone
+     *
+     * @param sourceDbId
+     *         ID of the source database
+     * @return database endpoint
+     */
+    private String getEndpointCloneFrom(String sourceDbId) {
+        return ApiLocator.getApiDevopsEndpoint(environment) + PATH_CLONE_1 + db.getId() + PATH_CLONE_2 + sourceDbId;
+    }
+
+
+}

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbOpsClient.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbOpsClient.java
@@ -408,6 +408,20 @@ public class DbOpsClient extends AbstractApiClient {
     public DbPrivateLinksClient privateLink() {
         return new DbPrivateLinksClient(token, environment, databaseId);
     }
+
+    // ---------------------------------
+    // ----         Clone           ----
+    // ---------------------------------
+
+    /**
+     * Delegate clone operation in a dedicated class
+     *
+     * @return clone client
+     */
+    public DbCloneClient clone() {
+        return new DbCloneClient(token, environment, databaseId);
+    }
+
     // ---------------------------------
     // ----       Snapshots         ----
     // ---------------------------------

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbOpsClient.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbOpsClient.java
@@ -408,6 +408,18 @@ public class DbOpsClient extends AbstractApiClient {
     public DbPrivateLinksClient privateLink() {
         return new DbPrivateLinksClient(token, environment, databaseId);
     }
+    // ---------------------------------
+    // ----       Snapshots         ----
+    // ---------------------------------
+
+    /**
+     * Delegate snapshots operation in a dedicated class
+     *
+     * @return snapshots client
+     */
+    public DbSnapshotsClient snapshots() {
+        return new DbSnapshotsClient(token, environment, databaseId);
+    }
 
     // ---------------------------------
     // ----       Utilities         ----

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbSnapshotsClient.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbSnapshotsClient.java
@@ -1,0 +1,130 @@
+package com.dtsx.astra.sdk.db;
+
+import com.dtsx.astra.sdk.AbstractApiClient;
+import com.dtsx.astra.sdk.db.domain.Database;
+import com.dtsx.astra.sdk.db.domain.DatabaseSnapshot;
+import com.dtsx.astra.sdk.db.domain.DatabaseSnapshotsResponse;
+import com.dtsx.astra.sdk.utils.ApiLocator;
+import com.dtsx.astra.sdk.utils.ApiResponseHttp;
+import com.dtsx.astra.sdk.utils.Assert;
+import com.dtsx.astra.sdk.utils.AstraEnvironment;
+import com.dtsx.astra.sdk.utils.JsonUtils;
+
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+/**
+ * Delegate operation on snapshots
+ */
+public class DbSnapshotsClient extends AbstractApiClient {
+
+    /** Get Available Regions. */
+    public static final String PATH_SNAPSHOTS_1 = "/databases/";
+
+    /** Get Available Regions. */
+    public static final String PATH_SNAPSHOTS_2 = "/snapshots";
+
+    /**
+     * unique db identifier.
+     */
+    private final Database db;
+
+    /**
+     * As immutable object use builder to initiate the object.
+     *
+     * @param token
+     *      authenticated token
+     * @param databaseId
+     *      database identifier
+     */
+    public DbSnapshotsClient(String token, String databaseId) {
+        this(token, AstraEnvironment.PROD, databaseId);
+    }
+
+    /**
+     * As immutable object use builder to initiate the object.
+     *
+     * @param env
+     *      define target environment to be used
+     * @param token
+     *      authenticated token
+     * @param databaseId
+     *      database identifier
+     */
+    public DbSnapshotsClient(String token, AstraEnvironment env, String databaseId) {
+        super(token, env);
+        Assert.hasLength(databaseId, "databaseId");
+        this.db = new DbOpsClient(token, env, databaseId).get();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getServiceName() {
+        return "db.snapshots";
+    }
+
+    /**
+     * Get snapshots with filters.
+     *
+     * @param from
+     *         start time (ISO 8601 format)
+     * @param to
+     *         end time (ISO 8601 format)
+     * @param region
+     *         region name
+     * @return list of snapshots.
+     */
+    public Stream<DatabaseSnapshot> find(String from, String to, String region) {
+        // Build URL with query parameters
+        StringBuilder url = new StringBuilder(getEndpointSnapshots());
+        boolean hasParams = false;
+        
+        if (region != null) {
+            url.append("?sourceRegion=").append(URLEncoder.encode(region, StandardCharsets.UTF_8));
+            hasParams = true;
+        }
+        
+        if (from != null) {
+            url.append(hasParams ? "&" : "?").append("from=").append(URLEncoder.encode(from, StandardCharsets.UTF_8));
+            hasParams = true;
+        }
+        
+        if (to != null) {
+            url.append(hasParams ? "&" : "?").append("to=").append(URLEncoder.encode(to, StandardCharsets.UTF_8));
+        }
+        
+        // Invoke endpoint
+        ApiResponseHttp res = GET(url.toString(), getOperationName("find"));
+        
+        // Handle response
+        if (HttpURLConnection.HTTP_NOT_FOUND == res.getCode()) {
+            return Stream.of();
+        } else {
+            DatabaseSnapshotsResponse response = JsonUtils.unmarshallBean(res.getBody(), DatabaseSnapshotsResponse.class);
+            return response.getSnapshots() != null ? response.getSnapshots().stream() : Stream.of();
+        }
+    }
+
+    /**
+     * Get all snapshots.
+     *
+     * @return list of snapshots.
+     */
+    public Stream<DatabaseSnapshot> findAll() {
+        return find(null, null, null);
+    }
+
+    // TODO: add other overloads here
+
+    /**
+     * Endpoint to access snapshots of a db
+     *
+     * @return database endpoint
+     */
+    private String getEndpointSnapshots() {
+        return ApiLocator.getApiDevopsEndpoint(environment) + PATH_SNAPSHOTS_1 + db.getId() + PATH_SNAPSHOTS_2;
+    }
+
+}

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbSnapshotsClient.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/DbSnapshotsClient.java
@@ -20,10 +20,10 @@ import java.util.stream.Stream;
  */
 public class DbSnapshotsClient extends AbstractApiClient {
 
-    /** Get Available Regions. */
+    /** Path for listing snapshots, part I. */
     public static final String PATH_SNAPSHOTS_1 = "/databases/";
 
-    /** Get Available Regions. */
+    /** Path for listing snapshots, part II. */
     public static final String PATH_SNAPSHOTS_2 = "/snapshots";
 
     /**

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseCloneStatus.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseCloneStatus.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtsx.astra.sdk.db.domain;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represent a database clone status.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseCloneStatus implements Serializable {
+    
+    /** Serial. */
+    private static final long serialVersionUID = 8242671294103939313L;
+
+    /** unique identifier for the operation. */
+    private String operationId;
+    
+    /** source database identifier. */
+    private String sourceDbId;
+    
+    /** target database identifier. */
+    private String targetDbId;
+    
+    /** current phase of the clone operation. */
+    private String phase;
+    
+    /** status of the clone operation. */
+    private String status;
+    
+    /** message with additional details. */
+    private String message;
+
+    /**
+     * Default constructor.
+     */
+    public DatabaseCloneStatus() {}
+
+    /**
+     * Getter accessor for attribute 'operationId'.
+     *
+     * @return
+     *       current value of 'operationId'
+     */
+    public String getOperationId() {
+        return operationId;
+    }
+
+    /**
+     * Setter accessor for attribute 'operationId'.
+     * @param operationId
+     * 		new value for 'operationId '
+     */
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
+    }
+
+    /**
+     * Getter accessor for attribute 'sourceDbId'.
+     *
+     * @return
+     *       current value of 'sourceDbId'
+     */
+    public String getSourceDbId() {
+        return sourceDbId;
+    }
+
+    /**
+     * Setter accessor for attribute 'sourceDbId'.
+     * @param sourceDbId
+     * 		new value for 'sourceDbId '
+     */
+    public void setSourceDbId(String sourceDbId) {
+        this.sourceDbId = sourceDbId;
+    }
+
+    /**
+     * Getter accessor for attribute 'targetDbId'.
+     *
+     * @return
+     *       current value of 'targetDbId'
+     */
+    public String getTargetDbId() {
+        return targetDbId;
+    }
+
+    /**
+     * Setter accessor for attribute 'targetDbId'.
+     * @param targetDbId
+     * 		new value for 'targetDbId '
+     */
+    public void setTargetDbId(String targetDbId) {
+        this.targetDbId = targetDbId;
+    }
+
+    /**
+     * Getter accessor for attribute 'phase'.
+     *
+     * @return
+     *       current value of 'phase'
+     */
+    public String getPhase() {
+        return phase;
+    }
+
+    /**
+     * Setter accessor for attribute 'phase'.
+     * @param phase
+     * 		new value for 'phase '
+     */
+    public void setPhase(String phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * Getter accessor for attribute 'status'.
+     *
+     * @return
+     *       current value of 'status'
+     */
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * Setter accessor for attribute 'status'.
+     * @param status
+     * 		new value for 'status '
+     */
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+     * Getter accessor for attribute 'message'.
+     *
+     * @return
+     *       current value of 'message'
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Setter accessor for attribute 'message'.
+     * @param message
+     * 		new value for 'message '
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+}

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseCloneStatus.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseCloneStatus.java
@@ -25,27 +25,39 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DatabaseCloneStatus implements Serializable {
-    
+
     /** Serial. */
     private static final long serialVersionUID = 8242671294103939313L;
 
     /** unique identifier for the operation. */
     private String operationId;
-    
+
     /** source database identifier. */
     private String sourceDbId;
-    
+
     /** target database identifier. */
     private String targetDbId;
-    
+
     /** current phase of the clone operation. */
     private String phase;
-    
+
     /** status of the clone operation. */
     private String status;
-    
+
     /** message with additional details. */
     private String message;
+
+    /** snapshot identifier. */
+    private String snapshotId;
+
+    /** timestamp when the clone was created. */
+    private String createdAt;
+
+    /** source region for the clone operation. */
+    private String sourceRegion;
+
+    /** target region for the clone operation. */
+    private String targetRegion;
 
     /**
      * Default constructor.
@@ -164,6 +176,82 @@ public class DatabaseCloneStatus implements Serializable {
      */
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    /**
+     * Getter accessor for attribute 'snapshotId'.
+     *
+     * @return
+     *       current value of 'snapshotId'
+     */
+    public String getSnapshotId() {
+        return snapshotId;
+    }
+
+    /**
+     * Setter accessor for attribute 'snapshotId'.
+     * @param snapshotId
+     * 		new value for 'snapshotId '
+     */
+    public void setSnapshotId(String snapshotId) {
+        this.snapshotId = snapshotId;
+    }
+
+    /**
+     * Getter accessor for attribute 'createdAt'.
+     *
+     * @return
+     *       current value of 'createdAt'
+     */
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Setter accessor for attribute 'createdAt'.
+     * @param createdAt
+     * 		new value for 'createdAt '
+     */
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * Getter accessor for attribute 'sourceRegion'.
+     *
+     * @return
+     *       current value of 'sourceRegion'
+     */
+    public String getSourceRegion() {
+        return sourceRegion;
+    }
+
+    /**
+     * Setter accessor for attribute 'sourceRegion'.
+     * @param sourceRegion
+     * 		new value for 'sourceRegion '
+     */
+    public void setSourceRegion(String sourceRegion) {
+        this.sourceRegion = sourceRegion;
+    }
+
+    /**
+     * Getter accessor for attribute 'targetRegion'.
+     *
+     * @return
+     *       current value of 'targetRegion'
+     */
+    public String getTargetRegion() {
+        return targetRegion;
+    }
+
+    /**
+     * Setter accessor for attribute 'targetRegion'.
+     * @param targetRegion
+     * 		new value for 'targetRegion '
+     */
+    public void setTargetRegion(String targetRegion) {
+        this.targetRegion = targetRegion;
     }
 
 }

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseSnapshot.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseSnapshot.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtsx.astra.sdk.db.domain;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represent a database snapshot.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseSnapshot implements Serializable {
+    
+    /** Serial. */
+    private static final long serialVersionUID = 8242671294103939312L;
+
+    /** unique identifier for the snapshot. */
+    private String id;
+    
+    /** snapshot time. */
+    private String time;
+
+    /**
+     * Default constructor.
+     */
+    public DatabaseSnapshot() {}
+
+    /**
+     * Getter accessor for attribute 'id'.
+     *
+     * @return
+     *       current value of 'id'
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Setter accessor for attribute 'id'.
+     * @param id
+     * 		new value for 'id '
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Getter accessor for attribute 'time'.
+     *
+     * @return
+     *       current value of 'time'
+     */
+    public String getTime() {
+        return time;
+    }
+
+    /**
+     * Setter accessor for attribute 'time'.
+     * @param time
+     * 		new value for 'time '
+     */
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+}

--- a/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseSnapshotsResponse.java
+++ b/astra-sdk-devops/src/main/java/com/dtsx/astra/sdk/db/domain/DatabaseSnapshotsResponse.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtsx.astra.sdk.db.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Response wrapper for database snapshots list.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseSnapshotsResponse implements Serializable {
+    
+    /** Serial. */
+    private static final long serialVersionUID = 1L;
+
+    /** list of snapshots. */
+    private List<DatabaseSnapshot> snapshots;
+
+    /**
+     * Default constructor.
+     */
+    public DatabaseSnapshotsResponse() {}
+
+    /**
+     * Getter accessor for attribute 'snapshots'.
+     *
+     * @return
+     *       current value of 'snapshots'
+     */
+    public List<DatabaseSnapshot> getSnapshots() {
+        return snapshots;
+    }
+
+    /**
+     * Setter accessor for attribute 'snapshots'.
+     * @param snapshots
+     * 		new value for 'snapshots '
+     */
+    public void setSnapshots(List<DatabaseSnapshot> snapshots) {
+        this.snapshots = snapshots;
+    }
+    
+}

--- a/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/AbstractDevopsApiTest.java
+++ b/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/AbstractDevopsApiTest.java
@@ -4,6 +4,7 @@ import com.dtsx.astra.sdk.db.DbOpsClient;
 import com.dtsx.astra.sdk.db.AstraDBOpsClient;
 import com.dtsx.astra.sdk.db.domain.DatabaseCreationRequest;
 import com.dtsx.astra.sdk.streaming.AstraStreamingClient;
+import com.dtsx.astra.sdk.utils.AstraEnvironment;
 import com.dtsx.astra.sdk.utils.AstraRc;
 import com.dtsx.astra.sdk.utils.Utils;
 import org.junit.jupiter.api.Assertions;
@@ -54,6 +55,26 @@ public abstract class AbstractDevopsApiTest {
     private static AstraStreamingClient streamingClient;
 
     /**
+     * Get the target Astra environment from ASTRA_ENV environment variable.
+     * Defaults to PROD if not set or invalid.
+     *
+     * @return
+     *      target environment
+     */
+    protected AstraEnvironment getEnvironment() {
+        return Utils.readEnvVariable(AstraRc.ASTRA_ENV)
+                .map(env -> {
+                    try {
+                        return AstraEnvironment.valueOf(env.toUpperCase());
+                    } catch (IllegalArgumentException e) {
+                        System.err.println("Invalid ASTRA_ENV value: " + env + ". Using PROD.");
+                        return AstraEnvironment.PROD;
+                    }
+                })
+                .orElse(AstraEnvironment.PROD);
+    }
+
+    /**
      * Access DB client.
      *
      * @return
@@ -61,7 +82,7 @@ public abstract class AbstractDevopsApiTest {
      */
     protected AstraOpsClient getApiDevopsClient() {
         if (apiDevopsClient == null) {
-            apiDevopsClient = new AstraOpsClient(getToken());
+            apiDevopsClient = new AstraOpsClient(getToken(), getEnvironment());
         }
         return apiDevopsClient;
     }
@@ -74,7 +95,7 @@ public abstract class AbstractDevopsApiTest {
      */
     protected AstraDBOpsClient getDatabasesClient() {
         if (databasesClient == null) {
-            databasesClient = new AstraDBOpsClient(getToken());
+            databasesClient = new AstraDBOpsClient(getToken(), getEnvironment());
         }
         return databasesClient;
     }
@@ -87,7 +108,7 @@ public abstract class AbstractDevopsApiTest {
      */
     protected AstraStreamingClient getStreamingClient() {
         if (streamingClient == null) {
-            streamingClient = new AstraStreamingClient(getToken());
+            streamingClient = new AstraStreamingClient(getToken(), getEnvironment());
         }
         return streamingClient;
     }

--- a/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/AbstractDevopsApiTest.java
+++ b/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/AbstractDevopsApiTest.java
@@ -35,44 +35,29 @@ public abstract class AbstractDevopsApiTest {
     private static String token;
 
     /**
+     * Hold reference to environment
+     */
+    private static AstraEnvironment env;
+
+    /**
      * Reference to Databases Client.
      */
-    private static AstraDBOpsClient databasesClient;
+    protected static AstraDBOpsClient databasesClient;
 
     /**
      * Reference to organization client.
      */
-    private static AstraOpsClient apiDevopsClient;
+    protected static AstraOpsClient apiDevopsClient;
 
     /**
      * Working db.
      */
-    private static DbOpsClient dbClient;
+    protected static DbOpsClient dbClient;
 
     /**
      * Reference to Databases Client.
      */
-    private static AstraStreamingClient streamingClient;
-
-    /**
-     * Get the target Astra environment from ASTRA_ENV environment variable.
-     * Defaults to PROD if not set or invalid.
-     *
-     * @return
-     *      target environment
-     */
-    protected AstraEnvironment getEnvironment() {
-        return Utils.readEnvVariable(AstraRc.ASTRA_ENV)
-                .map(env -> {
-                    try {
-                        return AstraEnvironment.valueOf(env.toUpperCase());
-                    } catch (IllegalArgumentException e) {
-                        System.err.println("Invalid ASTRA_ENV value: " + env + ". Using PROD.");
-                        return AstraEnvironment.PROD;
-                    }
-                })
-                .orElse(AstraEnvironment.PROD);
-    }
+    protected static AstraStreamingClient streamingClient;
 
     /**
      * Access DB client.
@@ -91,7 +76,7 @@ public abstract class AbstractDevopsApiTest {
      * Access DB client.
      *
      * @return
-     *      client fot databases
+     *      client for databases
      */
     protected AstraDBOpsClient getDatabasesClient() {
         if (databasesClient == null) {
@@ -129,6 +114,31 @@ public abstract class AbstractDevopsApiTest {
             token = Utils.readEnvVariable(AstraRc.ASTRA_DB_APPLICATION_TOKEN).orElse(token);
         }
         return token;
+    }
+
+    /**
+     * Get the target Astra environment from ASTRA_ENV environment variable.
+     * Defaults to PROD if not set or invalid.
+     *
+     * @return
+     *      target environment
+     */
+    protected AstraEnvironment getEnvironment() {
+        String envStr = null;
+        if (env == null) {
+            if (AstraRc.isDefaultConfigFileExists()) {
+                envStr = new AstraRc()
+                    .getSectionKey(AstraRc.ASTRARC_DEFAULT, AstraRc.ASTRA_ENV)
+                    .orElse(null);
+            }
+            envStr = Utils.readEnvVariable(AstraRc.ASTRA_ENV).orElse(envStr);
+            if (envStr == null) {
+                env = AstraEnvironment.PROD;
+            } else {
+                env = AstraEnvironment.valueOf(envStr);
+            }
+        }
+        return env;
     }
 
     /**

--- a/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
+++ b/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
@@ -3,6 +3,7 @@ package com.dtsx.astra.sdk.db;
 import com.dtsx.astra.sdk.AbstractDevopsApiTest;
 import com.dtsx.astra.sdk.db.domain.AccessListAddressRequest;
 import com.dtsx.astra.sdk.db.domain.CloudProviderType;
+import com.dtsx.astra.sdk.db.domain.DatabaseCloneStatus;
 import com.dtsx.astra.sdk.db.domain.DatabaseSnapshot;
 import com.dtsx.astra.sdk.db.domain.DatabaseStatusType;
 import com.dtsx.astra.sdk.db.domain.Datacenter;
@@ -298,6 +299,28 @@ public class DatabaseClientTest extends AbstractDevopsApiTest {
         Assertions.assertNotNull(theSnapshot);
         Assertions.assertNotNull(theSnapshot.getId());
         Assertions.assertNotNull(theSnapshot.getTime());
+    }
+
+    @Test
+    @Order(22)
+    @DisplayName("22. Should initiate a DB clone")
+    public void shouldInitiateCloneTest() {
+        /*
+        TODOS:
+        // actually ... I do not know where to start. This is probably not to be a test at all...
+        */
+        final String CLONE_DEV_REGION = "northamerica-northeast2";
+        final String CLONE_DEV_SOURCE_DB_NAME = "forcl";
+        final String CLONE_DEV_TARGET_DB_NAME = "destcl";
+        DbOpsClient dbSourceClient = getApiDevopsClient().db().databaseByName(CLONE_DEV_SOURCE_DB_NAME);
+        DbOpsClient dbTargetClient = getApiDevopsClient().db().databaseByName(CLONE_DEV_TARGET_DB_NAME);
+
+        DatabaseSnapshot theSnapshot = dbSourceClient.snapshots().findAll().findFirst().get();
+
+        DatabaseCloneStatus cloneStatus = dbTargetClient.clone().cloneFrom(dbSourceClient.getDatabaseId(), theSnapshot.getId());
+
+        // More articulated assertions here
+        Assertions.assertNotNull(cloneStatus);
     }
 
 }

--- a/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
+++ b/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
@@ -273,4 +273,16 @@ public class DatabaseClientTest extends AbstractDevopsApiTest {
         //Assert.assertEquals(0, getDatabasesClient().findByName(SDK_TEST_DB_NAME).count());
     }
 
+    @Test
+    @Order(21)
+    @DisplayName("21. Should list snapshots")
+    public void shouldListSnapshotsTest() {
+        // TODO refine the various query patterns and overloads as they come
+        int filteredSnapshotCount = (getSdkTestDatabaseClient().snapshots().find("2000-01-01T01:23:45.000Z", "2040-01-01T01:23:45.000Z", SDK_TEST_DB_REGION)).toList().size();
+        int fullSnapshotCount = (getSdkTestDatabaseClient().snapshots().findAll()).toList().size();
+        Assertions.assertTrue(filteredSnapshotCount <= fullSnapshotCount);
+        // TEMP: to ensure something is actually parsed back. The DB must be created more than ~1 h ago!
+        Assertions.assertTrue(fullSnapshotCount > 0);
+    }
+
 }

--- a/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
+++ b/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
@@ -281,19 +281,21 @@ public class DatabaseClientTest extends AbstractDevopsApiTest {
     public void shouldListSnapshotsTest() {
         /*
         TODOS:
-        // Create the "dbClient" environment-aware in the AbstractDevopsApiTest (and clean this mess)
-        // extract the region from the endpoint ?
+        // extract the region from the endpoint name
         // automate environment selection for tests? (clone is still in dev probably?)
         */
         final String CLONE_DEV_REGION = "northamerica-northeast2";
-        final String CLONE_DEV_DB_NAME = "forcl";
-        DbOpsClient dbClient = getApiDevopsClient().db().databaseByName(CLONE_DEV_DB_NAME);
+        final String CLONE_DEV_DB_ID = "6c446013-552d-4264-a0ee-74951d662722";
+        DbOpsClient dbClient = getApiDevopsClient().db().database(CLONE_DEV_DB_ID);
 
         // TODO refine the various query patterns and overloads as they come
-        int filteredSnapshotCount = (dbClient.snapshots().find("2000-01-01T01:23:45.000Z", "2040-01-01T01:23:45.000Z", CLONE_DEV_REGION)).toList().size();
+        int filteredSnapshotCount = (dbClient.snapshots().find(
+            "2000-01-01T01:23:45.000Z", "2040-01-01T01:23:45.000Z", CLONE_DEV_REGION
+        )).toList().size();
         int fullSnapshotCount = (dbClient.snapshots().findAll()).toList().size();
         Assertions.assertTrue(filteredSnapshotCount <= fullSnapshotCount);
-        // TEMP: to ensure something is actually parsed back. The DB must be created more than ~1 h ago!
+        // This is to ensure something is actually parsed back successfully.
+        // The DB must be created more than ~1 h ago. Alternatively can trigger a manual snapshot through Autobot
         Assertions.assertTrue(fullSnapshotCount > 0);
         DatabaseSnapshot theSnapshot = dbClient.snapshots().findAll().findFirst().get();
         Assertions.assertNotNull(theSnapshot);
@@ -307,20 +309,49 @@ public class DatabaseClientTest extends AbstractDevopsApiTest {
     public void shouldInitiateCloneTest() {
         /*
         TODOS:
-        // actually ... I do not know where to start. This is probably not to be a test at all...
+        // Maybe some parsing from endpoints for IDs and the region.
+        // Actually this whole test will not be a test that one really runs regularly (?)
         */
         final String CLONE_DEV_REGION = "northamerica-northeast2";
-        final String CLONE_DEV_SOURCE_DB_NAME = "forcl";
-        final String CLONE_DEV_TARGET_DB_NAME = "destcl";
-        DbOpsClient dbSourceClient = getApiDevopsClient().db().databaseByName(CLONE_DEV_SOURCE_DB_NAME);
-        DbOpsClient dbTargetClient = getApiDevopsClient().db().databaseByName(CLONE_DEV_TARGET_DB_NAME);
+        final String CLONE_DEV_SOURCE_DB_ID = "6c446013-552d-4264-a0ee-74951d662722";
+        final String CLONE_DEV_TARGET_DB_ID = "b19fd2ba-8ec6-4d18-b2a3-a4b404557748";
+        DbOpsClient dbSourceClient = getApiDevopsClient().db().database(CLONE_DEV_SOURCE_DB_ID);
+        DbOpsClient dbTargetClient = getApiDevopsClient().db().database(CLONE_DEV_TARGET_DB_ID);
 
         DatabaseSnapshot theSnapshot = dbSourceClient.snapshots().findAll().findFirst().get();
 
         DatabaseCloneStatus cloneStatus = dbTargetClient.clone().cloneFrom(dbSourceClient.getDatabaseId(), theSnapshot.getId());
 
-        // More articulated assertions here
         Assertions.assertNotNull(cloneStatus);
+        Assertions.assertNotNull(cloneStatus.getOperationId());
+        Assertions.assertEquals(cloneStatus.getSourceDbId(), CLONE_DEV_SOURCE_DB_ID);
+        Assertions.assertEquals(cloneStatus.getTargetDbId(), CLONE_DEV_TARGET_DB_ID);
+        Assertions.assertEquals(cloneStatus.getPhase(), "PreInit");
+    }
+
+    @Test
+    @Order(23)
+    @DisplayName("23. Should get a clone status by operation ID")
+    public void shouldGetCloneStatusByOperationId() {
+        /*
+        TODOS:
+        // Maybe some parsing from endpoints for the target db ID.
+        // Another test that might need to be scrapped away from here.
+        */
+        final String CLONE_OPERATION_ID = "01d0c7c9-c23b-43db-a92f-881af93c1e18";
+        final String CLONE_DEV_SOURCE_DB_ID = "6c446013-552d-4264-a0ee-74951d662722";
+        final String CLONE_DEV_TARGET_DB_ID = "b19fd2ba-8ec6-4d18-b2a3-a4b404557748";
+        final String CLONE_DEV_REGION = "northamerica-northeast2";
+        DbOpsClient dbTargetClient = getApiDevopsClient().db().database(CLONE_DEV_TARGET_DB_ID);
+
+        DatabaseCloneStatus cloneStatus = dbTargetClient.clone().getCloneStatus(CLONE_OPERATION_ID);
+
+        Assertions.assertNotNull(cloneStatus);
+        Assertions.assertEquals(cloneStatus.getOperationId(), CLONE_OPERATION_ID);
+        Assertions.assertEquals(cloneStatus.getSourceDbId(), CLONE_DEV_SOURCE_DB_ID);
+        Assertions.assertEquals(cloneStatus.getTargetDbId(), CLONE_DEV_TARGET_DB_ID);
+        Assertions.assertEquals(cloneStatus.getSourceRegion(), CLONE_DEV_REGION);
+        Assertions.assertEquals(cloneStatus.getTargetRegion(), CLONE_DEV_REGION);
     }
 
 }

--- a/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
+++ b/astra-sdk-devops/src/test/java/com/dtsx/astra/sdk/db/DatabaseClientTest.java
@@ -3,6 +3,7 @@ package com.dtsx.astra.sdk.db;
 import com.dtsx.astra.sdk.AbstractDevopsApiTest;
 import com.dtsx.astra.sdk.db.domain.AccessListAddressRequest;
 import com.dtsx.astra.sdk.db.domain.CloudProviderType;
+import com.dtsx.astra.sdk.db.domain.DatabaseSnapshot;
 import com.dtsx.astra.sdk.db.domain.DatabaseStatusType;
 import com.dtsx.astra.sdk.db.domain.Datacenter;
 import com.dtsx.astra.sdk.db.exception.KeyspaceAlreadyExistException;
@@ -277,12 +278,26 @@ public class DatabaseClientTest extends AbstractDevopsApiTest {
     @Order(21)
     @DisplayName("21. Should list snapshots")
     public void shouldListSnapshotsTest() {
+        /*
+        TODOS:
+        // Create the "dbClient" environment-aware in the AbstractDevopsApiTest (and clean this mess)
+        // extract the region from the endpoint ?
+        // automate environment selection for tests? (clone is still in dev probably?)
+        */
+        final String CLONE_DEV_REGION = "northamerica-northeast2";
+        final String CLONE_DEV_DB_NAME = "forcl";
+        DbOpsClient dbClient = getApiDevopsClient().db().databaseByName(CLONE_DEV_DB_NAME);
+
         // TODO refine the various query patterns and overloads as they come
-        int filteredSnapshotCount = (getSdkTestDatabaseClient().snapshots().find("2000-01-01T01:23:45.000Z", "2040-01-01T01:23:45.000Z", SDK_TEST_DB_REGION)).toList().size();
-        int fullSnapshotCount = (getSdkTestDatabaseClient().snapshots().findAll()).toList().size();
+        int filteredSnapshotCount = (dbClient.snapshots().find("2000-01-01T01:23:45.000Z", "2040-01-01T01:23:45.000Z", CLONE_DEV_REGION)).toList().size();
+        int fullSnapshotCount = (dbClient.snapshots().findAll()).toList().size();
         Assertions.assertTrue(filteredSnapshotCount <= fullSnapshotCount);
         // TEMP: to ensure something is actually parsed back. The DB must be created more than ~1 h ago!
         Assertions.assertTrue(fullSnapshotCount > 0);
+        DatabaseSnapshot theSnapshot = dbClient.snapshots().findAll().findFirst().get();
+        Assertions.assertNotNull(theSnapshot);
+        Assertions.assertNotNull(theSnapshot.getId());
+        Assertions.assertNotNull(theSnapshot.getTime());
     }
 
 }


### PR DESCRIPTION
This PR adds support for database self-service clone operations to the SDK.

To do so, two new clients are introduced, to which the main `DbOpsClient` delegates:
1. `DbSnapshotClient`, for snapshot-related actions (list snapshots)
2. `DbCloneClient`, for clone-related actions (initiate clone and, later, inspect the status of a clone operation)

The snapshot client only allows listing the snapshots for the current DB (with or without filter parameters).

The clone client offers methods to:
- initiate a clone _into the current DB_ from another DB and one of its snapshots
- inspect the status of an already-started clone _into the current DB_, given its Operation ID.

The reason to keep these two as separate clients is that the snapshots are focused on the _source_ DB (hence you create the client pointing at that DB), while the clone (+get status) essentially forget about the source and work "on" the target DB. So for a full clone interaction the user would have to spawn two DbOpsClient instances, true, but for a good reason (to keep their mind organized around how the two DB do what).

## Testing and such

Clone, right now, is testable mostly on DEV. (and even there, it often fails...)

So this PR also extends the general fixtures in `AbstractDevopsApiTest.java` to ensure DEV is properly targeted - this was needed by me in order to launch some tests.

The PR adds three tests, which however are probably not becoming ordinary tests that one runs frequently! They require quite some setup and some configuration (some of it, currently hardcoded in the test functions - let's see what should happen). My main goal was to see them working, it can then be decided later what to do of those.

### some trouble with me building/testing

_Note: not impacting the PR itself._

Right now, I could not properly build the repo with `skipTests=true` and succeed in later running a single test. Probably my limited knowledge. (_note I did not commit this pom change to this PR._)

I could not run the tests at all unless I changed the pom to say, `<skipTests>false</skipTests>`, so that I could later run e.g.

```
mvn -X surefire:test -pl astra-sdk-devops -Dtest=DatabaseClientTest#shouldGetCloneStatusByOperationId
```

But without skipping the tests, the build process (`mvn clean install -DskipTests=true`) would try to run the tests each time, despite the command-line flag.
So I Ctrl-C'd out of the build process as soon as the tests started (ahem, not very elegant, I know. Likely one can do better).
